### PR TITLE
Fix remaining occurrence of EX-NAME, changed to CONDITION-NAME

### DIFF
--- a/src/clack-errors.lisp
+++ b/src/clack-errors.lisp
@@ -78,7 +78,7 @@
                       (list key value))))))
 
 (defun render-prod (condition env)
-  (prod-page:index (list :name (ex-name condition)
+  (prod-page:index (list :name (condition-name condition)
                          :url (getf env :path-info)
                          :css (slurp-file *prod-css-path*))))
  


### PR DESCRIPTION
When using clack-errors with :debug set to NIL, it would try to call the function EX-NAME, which was renamed to CONDITION-NAME one commit ago.
