### PR TITLE
Rewrite it with handler-bind because handler-case doesn't keep stacks.

### DIFF
--- a/src/clack-errors.lisp
+++ b/src/clack-errors.lisp
@@ -91,15 +91,17 @@
 (defparameter *clack-error-middleware*
   (lambda (app &key (debug t) (prod-render #'render-prod))
     (lambda (env)
-      (handler-case
-          (funcall app env)
-        (t (condition)
-          (let ((backtrace (with-output-to-string (stream)
-                             (write-string (print-backtrace condition :output nil)
-                                           stream))))
-            (list 500
-                  '(:content-type "text/html")
-                  (list
-                   (if debug
-                       (render backtrace condition env)
-                       (funcall prod-render condition env))))))))))
+      (block nil
+        (handler-bind ((error
+                         (lambda (condition)
+                           (let ((backtrace (with-output-to-string (stream)
+                                              (write-string (print-backtrace condition :output nil)
+                                                            stream))))
+                             (return
+                               (list 500
+                                     '(:content-type "text/html")
+                                     (list
+                                      (if debug
+                                          (render backtrace condition env)
+                                          (funcall prod-render condition env)))))))))
+          (funcall app env))))))


### PR DESCRIPTION
Replaced `handler-case` by `handler-bind` because `handler-case` doesn't keep stacks.

You can reproduce the issue with this simple example:

```common-lisp
(defun raise-an-error ()
  (error "Something wrong"))

(clack:clackup
 (lack:builder
  clack-errors:*clack-error-middleware*
  (lambda (env)
    (declare (ignore env))
    (raise-an-error))))
```

When using `master` branch, `raise-an-error` isn't shown in stacktraces though it's where the error was signaled.