### PR TITLE
Add a system/package alias for Lack builder's naming convention.

### DIFF
--- a/lack-middleware-clack-errors.asd
+++ b/lack-middleware-clack-errors.asd
@@ -1,0 +1,6 @@
+(defsystem lack-middleware-clack-errors
+  :author "Fernando Borretti"
+  :license "LLGPL"
+  :description "Alias for clack-errors"
+  :homepage "https://github.com/eudoxia0/clack-errors"
+  :depends-on (:clack-errors))

--- a/src/clack-errors.lisp
+++ b/src/clack-errors.lisp
@@ -1,9 +1,11 @@
 (in-package :cl-user)
 (defpackage clack-errors
+  (:nicknames :lack.middleware.clack.errors)
   (:use :cl)
   (:import-from :trivial-backtrace
                 :print-backtrace)
-  (:export :*clack-error-middleware*))
+  (:export :*clack-error-middleware*
+           :*lack-middleware-clack-errors*))
 (in-package :clack-errors)
 
 (defparameter *dev-css-path*
@@ -103,3 +105,5 @@
                    (if debug
                        (render backtrace condition env)
                        (funcall prod-render condition env))))))))))
+
+(setf (symbol-value '*lack-middleware-clack-errors*) *clack-error-middleware*)


### PR DESCRIPTION
If the Lack middleware name is "lack.middleware." prefixed and comma-separated, Lack builder can find it from a keyword.

``` common-lisp
(lack:builder
  :clack-errors
  *app*)
```

It's possible to load it with placing the special variable, so it's okay to reject if you don't like it.

``` common-lisp
;; Requires to load clack-errors beforehand.
(lack:builder
  clack-errors:*clack-error-middleware*
  *app*)
```
